### PR TITLE
Fix command center not working

### DIFF
--- a/pytest/ContentView.swift
+++ b/pytest/ContentView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import AVFoundation
 import AVKit
-import SwiftAudioPlayer
 import Foundation
 import UIKit
 


### PR DESCRIPTION
Previously, the command center/now playing view for pausing/playing with native controls was broken.


<details>
<summary>
The issue was that when pausing, you **must not** use `playerNode.pause()` (AVAudioPlayerNode) -- instead you must use `engine.pause()` (AVAudioEngine), or else it breaks the command center playback.
</summary>
Side note: that there is no such thing as `engine.play` so you just call `playerNode.play()`. But it is imperative nevertheless to use `engine.pause()`. Why did Apple not document this 😭
</details>

However, the other issue with `engine.pause()` is when you resume playback, there's some glitching noise artifacts (this is also the same reason that I got rid of [`SwiftAudioPlayer`](https://github.com/tanhakabir/SwiftAudioPlayer). This issue however, does *not* happen when you use `playerNode.pause()`.

A hack fix for this is to "ramp up/down" the volume slowly when resuming/pausing (kind of like a fade in/out) to mask these noise artifacts. This practice isn't unique to this app: Spotify does this also.
