### PR TITLE
Potentially fix crashes

### DIFF
--- a/arbor/AudioPlayerWithReverb.swift
+++ b/arbor/AudioPlayerWithReverb.swift
@@ -323,7 +323,10 @@ class AudioPlayerWithReverb: ObservableObject {
         
         self.stop(queueAudio: false)
 
-        engine.reset()
+        engine.disconnectNodeOutput(reverbNode)
+        engine.disconnectNodeOutput(pitchNode)
+        engine.disconnectNodeOutput(playerNode)
+
         engine.disconnectNodeInput(reverbNode)
         engine.disconnectNodeInput(pitchNode)
         engine.disconnectNodeInput(playerNode)
@@ -331,6 +334,8 @@ class AudioPlayerWithReverb: ObservableObject {
         engine.detach(reverbNode)
         engine.detach(pitchNode)
         engine.detach(playerNode)
+
+        engine.reset()
 
         audioFile = nil
     }


### PR DESCRIPTION
Currently, the app randomly crashes if you downloaded a youtube video, go back, and do other actions.

<img width="1471" height="967" alt="Screenshot 2025-10-19 at 15 16 24" src="https://github.com/user-attachments/assets/c0f0da8d-2a54-43ae-a034-06b8804fb929" />

I was able to get ahold of a stack trace and it seems to be caused by the teardown function, specifically when we start disconnecting the node inputs.

GPT-5 implemented the fix:
```
### Why this fixes it

- AVAudioEngine maintains a directed graph. A node must have no active edges before it can be safely altered or detached. Disconnecting only the input of `reverbNode` leaves its output still connected to `mainMixerNode`, so the mixer still references `reverbNode`. Changing the graph in that state can hit internal assertions.

- Calling `engine.reset()` before disconnecting can invalidate the engine’s internal render state/caches while connections still exist. Subsequent disconnect calls can then target edges the engine believes don’t exist, leading to intermittent crashes.

- Stopping the engine first, then removing edges in topological order (downstream → upstream) eliminates dangling references:
  1) Disconnect node outputs (downstream nodes release their references),
  2) Disconnect inputs (upstream edges removed),
  3) Detach nodes,
  4) Reset last (clear internal state after the graph is empty).

- Doing it on the main actor and after stopping timers/observers also avoids races with the audio render thread.

In short: the fix preserves AVAudioEngine’s graph invariants while avoiding a reset mid-graph-change, so the engine never sees a partially broken connection state.
```