### PR TITLE
Satisfy new external JS runtime requirement for yt-dlp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 soundcloud-v2>=1.0.0,<2.0.0
 std-nslog>=1.0.0,<2.0.0
-yt-dlp==2025.10.22
+yt-dlp[default]==2025.11.1.232827.dev0
 ytmusicapi>=1.0.0,<2.0.0
+yt-dlp-apple-webkit-jsi


### PR DESCRIPTION
Two changes:
- Upgrade `yt-dlp` to the nightly version that enforces this requirement. Will upgrade to stable once this is pushed to the stable channel
- Add the [`yt-dlp-apple-webkit-jsi`](https://github.com/grqz/yt-dlp-apple-webkit-jsi) plugin so we can use the built-in JS runtime provided by WebKit for decoding. [See yt-dlp's wiki on this](https://github.com/yt-dlp/yt-dlp/wiki/EJS#plugins).

To my pleasant surprise, the plugin just ✨ works when you install it. No additional configurations or other wrangling required on my end:
<img width="1162" height="918" alt="Screenshot 2025-11-01 at 19 44 26" src="https://github.com/user-attachments/assets/d5f0e29b-dcbe-46e6-a384-d517811ea93f" />


It also feels much faster to download YouTube videos!
