### PR TITLE
Add options menu to player screen

### DIFF
--- a/Arbor/Library/Models.swift
+++ b/Arbor/Library/Models.swift
@@ -25,6 +25,7 @@ class LibraryItem {
     var speedRate: Float = 1.0
     var pitchCents: Float = 0.0
     var reverbMix: Float = 0.0
+    var isScrobblingOptedOut: Bool = false
     
     init(
         original_url: String,
@@ -37,7 +38,8 @@ class LibraryItem {
         thumbnail_is_square: Bool?,
         speedRate: Float = 1.0,
         pitchCents: Float = 0.0,
-        reverbMix: Float = 0.0
+        reverbMix: Float = 0.0,
+        isScrobblingOptedOut: Bool = false
     ) {
 
         self.original_url = original_url
@@ -51,6 +53,7 @@ class LibraryItem {
         self.speedRate = speedRate
         self.pitchCents = pitchCents
         self.reverbMix = reverbMix
+        self.isScrobblingOptedOut = isScrobblingOptedOut
     }
     
     convenience init(
@@ -70,7 +73,8 @@ class LibraryItem {
             thumbnail_is_square: meta.thumbnail_is_square,
             speedRate: speedRate,
             pitchCents: pitchCents,
-            reverbMix: reverbMix
+            reverbMix: reverbMix,
+            isScrobblingOptedOut: false
         )
     }
     
@@ -86,7 +90,8 @@ class LibraryItem {
             thumbnail_is_square: item.thumbnail_is_square,
             speedRate: item.speedRate,
             pitchCents: item.pitchCents,
-            reverbMix: item.reverbMix
+            reverbMix: item.reverbMix,
+            isScrobblingOptedOut: item.isScrobblingOptedOut
         )
     }
 }

--- a/Arbor/Library/ScrobbleCoordinator.swift
+++ b/Arbor/Library/ScrobbleCoordinator.swift
@@ -40,9 +40,13 @@ actor ScrobbleCoordinator {
         isPlaying: Bool,
         isAuthenticated: Bool,
         isScrobblingEnabled: Bool,
+        isTrackScrobblingEnabled: Bool,
         manager: SBKManager?
     ) async {
         handleScrobbleResetIfNeeded(currentTime: currentTime, isPlaying: isPlaying)
+
+        // Do not advance scrobble progress for tracks explicitly opted out.
+        guard isTrackScrobblingEnabled else { return }
 
         guard let scrobbleState,
               scrobbleState.shouldScrobble(currentTime: currentTime, isPlaying: isPlaying) else {


### PR DESCRIPTION
> [!NOTE]
> This PR was purely written by Codex, while code-reviewed by me

Implements a new options menu with the following:
1. Edit metadata of song
2. Share song link
3. Opt in/out of scrobbling a song
    - Modifies the iCloud schema by adding a new `isScrobblingOptedOut` key to the LibraryItem model