### PR TITLE
Refactor player state observation to prevent infinite rerenders

### DIFF
--- a/Arbor/ContentView.swift
+++ b/Arbor/ContentView.swift
@@ -93,7 +93,7 @@ struct ContentView: View {
                     .buttonStyle(.plain)
                     
                     if let audioPlayer = player.audioPlayer {
-                        PlayPauseButton(audioPlayer: audioPlayer)
+                        PlayPauseButton(audioPlayer: audioPlayer, playback: audioPlayer.playback)
                     }
                 }
                 .padding(.vertical, 4)
@@ -143,24 +143,24 @@ struct ContentView: View {
 }
 
 private struct PlayPauseButton: View {
-    // required so we can observe changes to the audio player's isPlaying property
-    @ObservedObject var audioPlayer: AudioPlayerWithReverb
+    let audioPlayer: AudioPlayerWithReverb
+    @ObservedObject var playback: AudioPlaybackState
     
     var body: some View {
         Button(action: {
-            if audioPlayer.isPlaying {
+            if playback.isPlaying {
                 audioPlayer.pause()
             } else {
                 audioPlayer.play()
             }
         }) {
-            Image(systemName: audioPlayer.isPlaying ? "pause.fill" : "play.fill")
+            Image(systemName: playback.isPlaying ? "pause.fill" : "play.fill")
                 .font(.title3)
                 .foregroundStyle(Color("PrimaryText"))
                 .frame(width: 36, height: 36)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(audioPlayer.isPlaying ? "Pause" : "Play")
+        .accessibilityLabel(playback.isPlaying ? "Pause" : "Play")
     }
 }
 

--- a/Arbor/Library/PlayerCoordinator.swift
+++ b/Arbor/Library/PlayerCoordinator.swift
@@ -127,7 +127,7 @@ final class PlayerCoordinator: ObservableObject {
         debugPrint("Monitoring audio player changes for library item: \(libraryItem.title)")
 
         // monitor changes to `duration`
-        audioPlayer.$duration
+        audioPlayer.playback.$duration
             .sink { [weak self] duration in
                 guard let self = self else { return }
                 Task {
@@ -137,7 +137,7 @@ final class PlayerCoordinator: ObservableObject {
             .store(in: &audioPlayerCancellables)
 
         // monitor changes to `currentTime` and `isPlaying`
-        Publishers.CombineLatest(audioPlayer.$currentTime, audioPlayer.$isPlaying)
+        Publishers.CombineLatest(audioPlayer.timeline.$currentTime, audioPlayer.playback.$isPlaying)
             .sink { [weak self] currentTime, isPlaying in
                 self?.handleScrobbleProgress(currentTime: currentTime, isPlaying: isPlaying)
             }

--- a/Arbor/Screens/PlayerScreen/EditMetadataSheet.swift
+++ b/Arbor/Screens/PlayerScreen/EditMetadataSheet.swift
@@ -12,7 +12,7 @@ import SwiftUI
 // https://stackoverflow.com/questions/60159490/swiftui-passing-an-environmentobject-to-a-sheet-causes-update-problems
 struct EditMetadataSheet: View {
     @Bindable var libraryItem: LibraryItem
-    @ObservedObject var audioPlayer: AudioPlayerWithReverb
+    let audioPlayer: AudioPlayerWithReverb
     let onLyricsInvalidated: () -> Void
     @Binding var isPresented: Bool
     
@@ -36,7 +36,7 @@ struct EditMetadataSheet: View {
 
 struct __EditMetadataSheet: View {
     @Bindable var libraryItem: LibraryItem
-    @ObservedObject var audioPlayer: AudioPlayerWithReverb
+    let audioPlayer: AudioPlayerWithReverb
     let player: PlayerCoordinator
     let lastFM: LastFMSession
     let onLyricsInvalidated: () -> Void
@@ -233,7 +233,13 @@ struct __EditMetadataSheet: View {
                 libraryItem.scrobbleTitle = nextScrobbleTitle
                 libraryItem.artists = trimmedArtists
                 
-                audioPlayer.updateMetadataTitle(decoratedTitle(for: libraryItem, audioPlayer: audioPlayer))
+                audioPlayer.updateMetadataTitle(
+                    decoratedTitle(
+                        for: libraryItem,
+                        speedRate: audioPlayer.speedRate,
+                        reverbMix: audioPlayer.reverbMix
+                    )
+                )
                 audioPlayer.updateMetadataArtist(formatArtists(libraryItem.artists))
                 player.updateScrobbleSeed(for: libraryItem)
                 


### PR DESCRIPTION
> [!NOTE]
> This PR was purely written by Codex (including the description)

## Summary
This PR reduces unnecessary Player UI re-renders by splitting audio state into focused observable objects and migrating views to observe only the state they need. It also fixes a regression where the download icon’s modified/saved state could become stale while changing effects.

## What changed

### 1) Split `AudioPlayerWithReverb` state by update frequency
- Introduced:
  - `AudioPlaybackState` (`isPlaying`, `duration`, `isLooping`)
  - `AudioTimelineState` (`currentTime`)
  - `AudioEffectsState` (`speedRate`, `pitchCents`, `reverbMix`)
  - `AudioEffectSnapshot` (for effect comparisons)
- `AudioPlayerWithReverb` now acts as command/controller and exposes:
  - `playback`, `timeline`, `effects`
- Kept compatibility read accessors on `AudioPlayerWithReverb` (`isPlaying`, `currentTime`, `duration`, etc.) to preserve existing call patterns during migration.

### 2) Move coordinator subscriptions to split state
- In `PlayerCoordinator`:
  - Duration subscription now uses `audioPlayer.playback.$duration`
  - Progress subscription now uses `CombineLatest(audioPlayer.timeline.$currentTime, audioPlayer.playback.$isPlaying)`

### 3) Migrate UI observers to scoped state
- `ContentView` mini-player play/pause button now observes `AudioPlaybackState` instead of observing the full player.
- `LyricsView` + full-screen lyrics controls now consume:
  - commands via `audioPlayer`
  - playback state via `playback`
  - timeline ticks via `timeline`
- `EditMetadataSheet` now holds `audioPlayer` as a plain `let` (no `@ObservedObject`) to avoid tick-driven sheet re-renders.

### 4) Fix stale toolbar modified-state feedback
- `PlayerScreen` no longer computes `isToolbarModified` at parent level.
- Added `DownloadToolbarButton` that observes `AudioEffectsState` directly and computes modified state locally using:
  - saved values (if present), else library baseline values
- Result: download icon updates immediately on effect changes while keeping broader toolbar/menu rerenders minimized.

### 5) Simplify title helper API
- Consolidated `decoratedTitle` to a single signature:
  - `decoratedTitle(for:speedRate:reverbMix:)`
- Updated call sites in `PlayerScreen` and `EditMetadataSheet`.

## Notes
- This is a state-management/refactor PR; behavior is intended to remain functionally equivalent except for the toolbar modified-state fix.  