### PR TITLE
Increase quality of speed changes

### DIFF
--- a/Arbor/Library/AudioPlayerWithReverb.swift
+++ b/Arbor/Library/AudioPlayerWithReverb.swift
@@ -87,6 +87,7 @@ final class AudioPlayerWithReverb {
                 
         // Default parameters
         reverbNode.wetDryMix = effects.reverbMix
+        pitchNode.overlap = 32.0 // to increase quality of speed changes. see https://developer.apple.com/documentation/avfaudio/avaudiounittimepitch/overlap
         pitchNode.rate = effects.speedRate
         
         // Connect nodes: player -> pitch -> reverb -> output


### PR DESCRIPTION
> [!NOTE]
> This PR was purely written by Codex

Right now changing the speed when you have the pitch changed causes not very nice audio artifacts.

Per Apple's docs you can set the `output` attr of the time pitch node from 3.0 to 32.0 to help with this. By default it is 8.0 so I just dialed it all the way up to 32.0 for now. It's not perfect but it is better than no improvement.

https://developer.apple.com/documentation/avfaudio/avaudiounittimepitch/overlap